### PR TITLE
 Add --last-accessed option for delete subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
 **thumbs** is a CLI tool to manage the cached thumbnails for files.
-
 <!-- next-header -->
 ## [Unreleased] - TBD
 
+### Added
+
+* New `-l/--last-accessed <timestamp/duration>` option for `delete` that allows deleting only thumbnails for file that have not been accessed since that time. The argument can be either a RFC3339-like time-stamp (`2020-01-01 11:10:00`) or a free-form duration like `1year 15days 1week 2min` or `1h 6s 2ms` that is taken from the current time.
 
 ## [0.2.2] - 2021-07-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,9 +201,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "log"
@@ -418,6 +418,7 @@ dependencies = [
  "dirs",
  "env_logger",
  "globset",
+ "humantime",
  "log",
  "md5",
  "png_pong",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ dirs = "3"
 walkdir = "2.2"
 globset = "0.4"
 png_pong = "0.8"
+humantime = "2"
 
 [profile.release]
 lto = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,8 +82,12 @@ fn run() -> Result<bool> {
 
             Ok(nb_thumbs != 0)
         }
-        Command::Delete { dry_run, files } => {
-            let results = un.delete(&files, *dry_run)?;
+        Command::Delete {
+            dry_run,
+            files,
+            last_accessed,
+        } => {
+            let results = un.delete(files, *dry_run, *last_accessed)?;
             if results.ignored_directories != 0 {
                 warn!(
                     "Ignoring {} folder(s). Enable '-r/--recursive' to recurse into directories.",


### PR DESCRIPTION
Add a last-access option for the `delete` subcommand.

humantime is used to parse either a timestamp of a free-form human
duration, and that is compared to the access time of files.
