### PR TITLE
Feature: prompt for action when on tty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@
 
 ### Changes
 
+* `delete` now requires `-f/--force` to actually delete thumbnails and will otherwise prompt (on tty).
+* `delete` has no `-d/--dry-run` option anymore: it is now the default behavior.
+
 ### Features
 
-* New `-l/--last-accessed <timestamp/duration>` option for `delete` that allows deleting only thumbnails for file that have not been accessed since that time. The argument can be either a RFC3339-like time-stamp (`2020-01-01 11:10:00`) or a free-form duration like `1year 15days 1week 2min` or `1h 6s 2ms` that is taken from the current time.
+* New `-l/--last-accessed <timestamp/duration>` option for `delete`. It allows deleting only thumbnails for file that have not been accessed since that time. The argument can be either a RFC3339-like time-stamp (`2020-01-01 11:10:00`) or a free-form duration like `1year 15days 1week 2min` or `1h 6s 2ms` that is taken from the current time.
+* thumbs will now prompt for action when connected to a tty, with 3 options `y/N/d` for deletion, doing nothing, and printing the files whose thumbnails will be deleted, respectively.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,17 @@
 <!-- next-header -->
 ## [Unreleased] - TBD
 
-### Added
+### Packaging
+
+### Changes
+
+### Features
 
 * New `-l/--last-accessed <timestamp/duration>` option for `delete` that allows deleting only thumbnails for file that have not been accessed since that time. The argument can be either a RFC3339-like time-stamp (`2020-01-01 11:10:00`) or a free-form duration like `1year 15days 1week 2min` or `1h 6s 2ms` that is taken from the current time.
+
+### Fixes
+
+### Other
 
 ## [0.2.2] - 2021-07-09
 
@@ -17,7 +25,6 @@
 ### Fixed
 
 * `locate` accidentally took multiple paths, like `delete`. It now only take a single path (which doesn't have to exist).
-
 
 ## [0.2.1] - 2021-07-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
+checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 
 [[package]]
 name = "atty"
@@ -415,6 +415,7 @@ name = "thumbs"
 version = "0.3.0-dev"
 dependencies = [
  "anyhow",
+ "atty",
  "dirs",
  "env_logger",
  "globset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ md5 = "0.7"
 log = "0.4"
 env_logger = "0.8"
 dirs = "3"
-walkdir = "2.2"
+walkdir = "2"
 globset = "0.4"
 png_pong = "0.8"
 humantime = "2"
+atty = "0.2"
 
 [profile.release]
 lto = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,8 +57,8 @@ pub enum Command {
     /// Delete the thumbnails for the given files
     Delete {
         #[structopt(short, long)]
-        /// Do not actually delete anything
-        dry_run: bool,
+        /// Do not prompt and actually delete thumbnails
+        force: bool,
 
         #[structopt(parse(from_os_str))]
         /// Files whose thumbnails to delete


### PR DESCRIPTION
This will prompt for y/N/d (yes, no, details) when running `delete` or
`cleanup` with a non-zero number of results and stdout is a tty.

Yes will delete the thumbnails without having to rerun the search, No
(the default) does nothing, and Details prints the list of files about
to be deleted.

We also change the default for `delete` to be the previous `dry-run`
mode, with `-f/--force` bypassing the prompt (`-d/--dry-run was
removed).
