### PR TITLE
Update build-info-build to drop unmaintained bincode dependency

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.87.0 # Rust MSRV
+          - 1.88.0 # Rust MSRV
     steps:
       - uses: actions/checkout@v6
       - name: Setup
@@ -38,7 +38,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.87.0 # Rust MSRV
+          - 1.88.0 # Rust MSRV
     steps:
       - uses: actions/checkout@v6
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }} && rustup component add clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 <!-- next-header -->
 ## [Unreleased] - TBD
 
+### Packaging
+
+* The Minimum Supported Rust Version for thumbs is now 1.88.
+
 ## [0.5.2] - 2026-05-18
 
 ### Packaging

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,32 +119,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,29 +137,29 @@ dependencies = [
 
 [[package]]
 name = "build-info-build"
-version = "0.0.42"
+version = "0.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b090e1d116997848529faaf849e1efd592cbe6e9eb44623c0588f017c63bbc4"
+checksum = "93c808dbd5c28f097b574cb2f5808aca8c6486351bbee5cdb48a379ac091106f"
 dependencies = [
  "anyhow",
- "base64",
- "bincode",
  "build-info-common",
  "cargo_metadata",
  "chrono",
+ "ciborium",
  "git2",
  "glob",
  "pretty_assertions",
  "rustc_version",
  "serde_json",
+ "z85",
  "zstd",
 ]
 
 [[package]]
 name = "build-info-common"
-version = "0.0.42"
+version = "0.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a436965b6554ae18aba994745234bf2ed98d2c984e96b58aeb0f845c666969"
+checksum = "52a3f141b0116f00ce3a1b6082c061c83ffd5a167a0d7ff5a4db479cd2974226"
 dependencies = [
  "chrono",
  "derive_more",
@@ -265,6 +239,33 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -371,6 +372,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "derive_more"
@@ -563,6 +570,17 @@ dependencies = [
  "bitflags",
  "ignore",
  "walkdir",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1283,12 +1301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,12 +1329,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"
@@ -1525,6 +1531,32 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "z85"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e61e59a957b7ccee15d2049f86e8bfd6f66968fcd88f018950662d9b86e675"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["xtask"]
 [workspace.package]
 authors = ["Antoine Gourlay <antoine@gourlay.fr>"]
 edition = "2024"
-rust-version = "1.87"
+rust-version = "1.88"
 license = "Apache-2.0"
 
 # Global dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ assert_cmd = "2.2"
 predicates = "3.1"
 
 [build-dependencies]
-build-info-build = "0.0.42"
+build-info-build = "0.0.44"
 anyhow = "1"
 clap = { workspace = true }
 clap_complete = "4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,10 +22,10 @@ pub(crate) fn cached_delete(thumbnails: &[Thumbnail]) {
                 if let Ok(p) = uri.to_file_path() {
                     debug!("Deleting thumbnail for {}", p.display());
                 } else {
-                    debug!("Deleting thumbnail for {}", uri);
+                    debug!("Deleting thumbnail for {uri}");
                 }
             } else {
-                debug!("Deleting thumbnail for {}", uri);
+                debug!("Deleting thumbnail for {uri}");
             }
 
             if let Err(e) = p.delete() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,7 +3,8 @@ use std::io::{Error, Write};
 use flexi_logger::{AdaptiveFormat, DeferredNow, style};
 use log::Record;
 
-pub const ADAPTIVE_LOG_FORMAT: AdaptiveFormat = AdaptiveFormat::Custom(default_format, colored_default_format);
+pub const ADAPTIVE_LOG_FORMAT: AdaptiveFormat =
+    AdaptiveFormat::Custom(default_format, colored_default_format);
 
 pub fn syslog_prefixed_format(
     w: &mut dyn Write,
@@ -18,10 +19,10 @@ pub fn syslog_prefixed_format(
         log::Level::Debug | log::Level::Trace => "<7>",
     };
 
-    if let Some(m) = record.module_path() {
-        if m.starts_with("thumbs") {
-            return write!(w, "{prefix}{}", record.args());
-        }
+    if let Some(m) = record.module_path()
+        && m.starts_with("thumbs")
+    {
+        return write!(w, "{prefix}{}", record.args());
     }
 
     write!(
@@ -39,10 +40,10 @@ pub fn default_format(
     record: &Record,
 ) -> Result<(), Error> {
     let level = record.level();
-    if let Some(m) = record.module_path() {
-        if m.starts_with("thumbs") {
-            return write!(w, "{} {}", level, record.args());
-        }
+    if let Some(m) = record.module_path()
+        && m.starts_with("thumbs")
+    {
+        return write!(w, "{} {}", level, record.args());
     }
 
     write!(
@@ -62,15 +63,15 @@ pub fn colored_default_format(
 ) -> Result<(), Error> {
     let level = record.level();
 
-    if let Some(m) = record.module_path() {
-        if m.starts_with("thumbs") {
-            return write!(
-                w,
-                "{} {}",
-                style(level).paint(level.to_string()),
-                style(level).paint(record.args().to_string())
-            );
-        }
+    if let Some(m) = record.module_path()
+        && m.starts_with("thumbs")
+    {
+        return write!(
+            w,
+            "{} {}",
+            style(level).paint(level.to_string()),
+            style(level).paint(record.args().to_string())
+        );
     }
 
     write!(

--- a/thumbs-rs/src/lib.rs
+++ b/thumbs-rs/src/lib.rs
@@ -22,7 +22,7 @@
  *             }
  *         }
  *     }
- * 
+ *
  *     Ok(())
  * }
  * ```
@@ -148,10 +148,10 @@ impl ThumbnailCache {
 
         for path in paths {
             if path.is_file() {
-                if let Some(last_accessed) = last_accessed {
-                    if is_atime_younger_than(path, last_accessed) {
-                        continue;
-                    }
+                if let Some(last_accessed) = last_accessed
+                    && is_atime_younger_than(path, last_accessed)
+                {
+                    continue;
                 };
                 thumbnails.extend(self.find_thumbnails_for_file(path)?);
                 continue;
@@ -173,10 +173,10 @@ impl ThumbnailCache {
                         nb_ignore_dirs += 1;
                         continue;
                     }
-                } else if let Some(last_accessed) = last_accessed {
-                    if is_atime_younger_than(entry.path(), last_accessed) {
-                        continue;
-                    }
+                } else if let Some(last_accessed) = last_accessed
+                    && is_atime_younger_than(entry.path(), last_accessed)
+                {
+                    continue;
                 };
 
                 thumbnails.extend(self.find_thumbnails_for_file(entry.path())?);

--- a/thumbs-rs/src/thumbnail.rs
+++ b/thumbs-rs/src/thumbnail.rs
@@ -141,21 +141,21 @@ impl Thumbnail {
         let metadata = path
             .metadata()
             .map_err(|e| ThumbnailError::from(self.path(), e.into()))?;
-        if let Some(size) = self.size {
-            if size != metadata.size() {
-                return Ok(true);
-            }
+        if let Some(size) = self.size
+            && size != metadata.size()
+        {
+            return Ok(true);
         }
 
-        if let Some(m_time) = self.m_time {
-            if let Ok(file_m_time) = metadata.modified() {
-                let file_m_time = file_m_time
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs();
-                if file_m_time != m_time {
-                    return Ok(true);
-                }
+        if let Some(m_time) = self.m_time
+            && let Ok(file_m_time) = metadata.modified()
+        {
+            let file_m_time = file_m_time
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+            if file_m_time != m_time {
+                return Ok(true);
             }
         }
 


### PR DESCRIPTION
See RUSTSEC-2025-0141.

- **build: update to MSRV 1.88**
- **build: update build-info-build to drop unmaintained bincode dependency**
